### PR TITLE
理論値ベースの聖遺物スコアの算出を実装

### DIFF
--- a/cogs/artifact.py
+++ b/cogs/artifact.py
@@ -231,7 +231,7 @@ class Artifact(commands.Cog):
         embed.add_field(name='サブステータス',
                         value='\n'.join(stats), inline=False)
         embed.add_field(name='スコア', value=score, inline=False)
-        embed.add_field(name='上昇割合', value=rate, inline=False)
+        embed.add_field(name='理論値比', value=f'{rate}%', inline=False)
         return embed
 
 

--- a/cogs/artifact.py
+++ b/cogs/artifact.py
@@ -195,7 +195,7 @@ class Artifact(commands.Cog):
         return stats
 
     def get_value(self, stat):
-        return Decimal(stat.split('+')[1].replace('%', ''))
+        return float(stat.split('+')[1].replace('%', ''))
 
     def calc_score(self, t, stats):
         extracted_stats = {}

--- a/cogs/theoretical_artifact_score.py
+++ b/cogs/theoretical_artifact_score.py
@@ -1,0 +1,131 @@
+from decimal import Decimal, ROUND_HALF_UP
+
+
+class TheoreticalArtifactScore:
+    theoretical_value = {
+        "fixed_hp": 299,
+        "fixed_atk": 19,
+        "fixed_def": 23,
+        "rated_hp": 5.8,
+        "rated_atk": 5.8,
+        "rated_def": 7.3,
+        "crit_dmg": 7.8,
+        "crit_rate": 3.9,
+        "charge_rate": 6.5,
+        "elemental_mastery": 23,
+    }
+
+    def __init__(
+        self,
+        fixed_hp: int = 0,
+        fixed_atk: int = 0,
+        fixed_def: int = 0,
+        rated_hp: float = 0.0,
+        rated_atk: float = 0.0,
+        rated_def: float = 0.0,
+        crit_dmg: float = 0.0,
+        crit_rate: float = 0.0,
+        charge_rate: float = 0.0,
+        elemental_mastery: int = 0,
+    ):
+        self.fixed_hp = fixed_hp
+        self.fixed_atk = fixed_atk
+        self.fixed_def = fixed_def
+        self.rated_hp = rated_hp
+        self.rated_atk = rated_atk
+        self.rated_def = rated_def
+        self.crit_dmg = crit_dmg
+        self.crit_rate = crit_rate
+        self.charge_rate = charge_rate
+        self.elemental_mastery = elemental_mastery
+
+    def _quantize(self, value: float) -> Decimal:
+        return Decimal(value).quantize(Decimal("0.1"), ROUND_HALF_UP)
+
+    def _calc_theoretical_rate(
+        self, attr: str, initial: int = 1, raises: int = 5
+    ) -> float:
+        """
+        オプション上昇理論値から見た割合を算出する
+
+        現在値 / 1回の上昇量の理論値 * (オプション初期値として扱う値 + オプション上昇回数)
+        """
+        return getattr(self, attr) / (self.theoretical_value[attr] * (initial + raises))
+
+    def calc_theoretical_rate(
+        self, attrs: "list[str] | None" = None, raises: int = 5
+    ) -> Decimal:
+        """
+        選択したオプションと、上昇回数から想定される理論値から見た割合を算出する
+        """
+        if attrs is None:
+            attrs = [
+                attr for attr in self.theoretical_value.keys() if getattr(self, attr)
+            ]
+        rates: list[float] = [
+            self._calc_theoretical_rate(attr, initial=len(attrs), raises=raises)
+            for attr in attrs
+        ]
+        return self._quantize(sum(rates) * 100)
+
+
+if __name__ == "__main__":
+    # 手持ちのそこそこ強い羽
+    tas = TheoreticalArtifactScore(
+        fixed_hp=209,
+        rated_hp=9.9,
+        crit_rate=10.1,
+        crit_dmg=20.2,
+    )
+    # 会心率オプションとしての理論値から見た割合
+    # 43.162393162393165
+    print(tas.calc_theoretical_rate(["crit_rate"]))
+
+    # 会心率が2回伸びた際の理論値から見た割合
+    # 86.32478632478633
+    print(tas.calc_theoretical_rate(["crit_rate"], 2))
+
+    # hp固定値を除いた聖遺物の理論値から見た割合
+    # 86.07979664014147
+    print(tas.calc_theoretical_rate(["crit_rate", "crit_dmg", "rated_hp"]))
+
+    # 聖遺物としての理論値から見た割合
+    # 84.28200429699679
+    print(tas.calc_theoretical_rate())
+
+    # 適当に理論上最弱聖遺物
+    tas = TheoreticalArtifactScore(
+        fixed_hp=209 * 6,
+        rated_hp=4.1,
+        crit_rate=2.7,
+        crit_dmg=5.4,
+    )
+    # 会心率オプションとしての理論値から見た割合
+    # 11.53846153846154
+    print(tas.calc_theoretical_rate(["crit_rate"]))
+
+    # hp固定値が5回伸びた際の理論値から見た割合
+    # 69.89966555183946
+    print(tas.calc_theoretical_rate(["fixed_hp"], 5))
+
+    # hp固定値を除いた聖遺物としての理論値から見た割合
+    # 26.143899204244036
+    print(tas.calc_theoretical_rate(["crit_rate", "crit_dmg", "rated_hp"]))
+
+    # 聖遺物としての理論値スコア
+    # 69.83879854944321
+    print(tas.calc_theoretical_rate())
+
+    # 適当に理論上最強聖遺物
+    tas = TheoreticalArtifactScore(
+        elemental_mastery=23,
+        charge_rate=6.5,
+        crit_rate=3.9 * 3,
+        crit_dmg=7.8 * 4,
+    )
+    # 率ダメ理論値スコア
+    # 100
+    print(tas.calc_theoretical_rate(["crit_rate", "crit_dmg"]))
+    # 理論値スコア
+    # 100
+    print(tas.calc_theoretical_rate())

--- a/cogs/theoretical_artifact_score.py
+++ b/cogs/theoretical_artifact_score.py
@@ -3,16 +3,16 @@ from decimal import Decimal, ROUND_HALF_UP
 
 class TheoreticalArtifactScore:
     theoretical_value = {
-        "fixed_hp": 299,
-        "fixed_atk": 19,
-        "fixed_def": 23,
-        "rated_hp": 5.8,
-        "rated_atk": 5.8,
-        "rated_def": 7.3,
-        "crit_dmg": 7.8,
-        "crit_rate": 3.9,
-        "charge_rate": 6.5,
-        "elemental_mastery": 23,
+        'fixed_hp': 299,
+        'fixed_atk': 19,
+        'fixed_def': 23,
+        'rated_hp': 5.8,
+        'rated_atk': 5.8,
+        'rated_def': 7.3,
+        'crit_dmg': 7.8,
+        'crit_rate': 3.9,
+        'charge_rate': 6.5,
+        'elemental_mastery': 23,
     }
 
     def __init__(
@@ -39,8 +39,20 @@ class TheoreticalArtifactScore:
         self.charge_rate = charge_rate
         self.elemental_mastery = elemental_mastery
 
+    def _calc_by_general_score_logic(self, calc_type: str) -> float:
+        if calc_type == 'rated_hp':
+            return self.crit_rate * 2 + self.crit_dmg + self.rated_hp
+        if calc_type == 'rated_atk':
+            return self.crit_rate * 2 + self.crit_dmg + self.rated_atk
+        if calc_type == 'crit_only':
+            return self.crit_rate * 2 + self.crit_dmg
+        return 0
+    
+    def calc_general_rate(self, calc_type: str) -> Decimal:
+        return self._quantize(self._calc_by_general_score_logic(calc_type))
+
     def _quantize(self, value: float) -> Decimal:
-        return Decimal(value).quantize(Decimal("0.1"), ROUND_HALF_UP)
+        return Decimal(value).quantize(Decimal('0.1'), ROUND_HALF_UP)
 
     def _calc_theoretical_rate(
         self, attr: str, initial: int = 1, raises: int = 5
@@ -53,7 +65,7 @@ class TheoreticalArtifactScore:
         return getattr(self, attr) / (self.theoretical_value[attr] * (initial + raises))
 
     def calc_theoretical_rate(
-        self, attrs: "list[str] | None" = None, raises: int = 5
+        self, attrs: 'list[str] | None' = None, raises: int = 5
     ) -> Decimal:
         """
         選択したオプションと、上昇回数から想定される理論値から見た割合を算出する
@@ -69,7 +81,7 @@ class TheoreticalArtifactScore:
         return self._quantize(sum(rates) * 100)
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     # 手持ちのそこそこ強い羽
     tas = TheoreticalArtifactScore(
         fixed_hp=209,
@@ -79,15 +91,15 @@ if __name__ == "__main__":
     )
     # 会心率オプションとしての理論値から見た割合
     # 43.162393162393165
-    print(tas.calc_theoretical_rate(["crit_rate"]))
+    print(tas.calc_theoretical_rate(['crit_rate']))
 
     # 会心率が2回伸びた際の理論値から見た割合
     # 86.32478632478633
-    print(tas.calc_theoretical_rate(["crit_rate"], 2))
+    print(tas.calc_theoretical_rate(['crit_rate'], 2))
 
     # hp固定値を除いた聖遺物の理論値から見た割合
     # 86.07979664014147
-    print(tas.calc_theoretical_rate(["crit_rate", "crit_dmg", "rated_hp"]))
+    print(tas.calc_theoretical_rate(['crit_rate', 'crit_dmg', 'rated_hp']))
 
     # 聖遺物としての理論値から見た割合
     # 84.28200429699679
@@ -102,15 +114,15 @@ if __name__ == "__main__":
     )
     # 会心率オプションとしての理論値から見た割合
     # 11.53846153846154
-    print(tas.calc_theoretical_rate(["crit_rate"]))
+    print(tas.calc_theoretical_rate(['crit_rate']))
 
     # hp固定値が5回伸びた際の理論値から見た割合
     # 69.89966555183946
-    print(tas.calc_theoretical_rate(["fixed_hp"], 5))
+    print(tas.calc_theoretical_rate(['fixed_hp'], 5))
 
     # hp固定値を除いた聖遺物としての理論値から見た割合
     # 26.143899204244036
-    print(tas.calc_theoretical_rate(["crit_rate", "crit_dmg", "rated_hp"]))
+    print(tas.calc_theoretical_rate(['crit_rate', 'crit_dmg', 'rated_hp']))
 
     # 聖遺物としての理論値スコア
     # 69.83879854944321
@@ -125,7 +137,7 @@ if __name__ == "__main__":
     )
     # 率ダメ理論値スコア
     # 100
-    print(tas.calc_theoretical_rate(["crit_rate", "crit_dmg"]))
+    print(tas.calc_theoretical_rate(['crit_rate', 'crit_dmg']))
     # 理論値スコア
     # 100
     print(tas.calc_theoretical_rate())

--- a/cogs/theoretical_artifact_score.py
+++ b/cogs/theoretical_artifact_score.py
@@ -62,7 +62,10 @@ class TheoreticalArtifactScore:
         return 0
     
     def calc_general_rate(self, calc_type: str) -> Decimal:
-        return self._quantize(self._calc_by_general_score_logic(calc_type))
+        return self._quantize(
+            self._calc_by_general_score_logic(calc_type),
+            method=ROUND_HALF_UP,
+        )
 
     def _quantize(self, value: float, rank: str='0.1', method:str = ROUND_DOWN) -> Decimal:
         return Decimal(value).quantize(Decimal(rank), method)
@@ -130,6 +133,8 @@ if __name__ == '__main__':
     print(tas.calc_theoretical_rate(['crit_rate', 'crit_dmg', 'rated_atk']))
     # トータルスコア: 100.0
     print(tas.calc_theoretical_rate())
+    # 一般的な聖遺物スコアが理論値の 60.3であることの確認
+    assert tas.calc_general_rate('rated_atk') == Decimal('60.3')
     
     # 理論値で100.0になることを確認する
     theoretical_values=dict(


### PR DESCRIPTION
## 概要
目検で算出のしにくい、「理論値をもとにしたサブオプションの割合」を計算できるようにしてみました

## やったこと
- メインとなる算出クラスの実装
- 一般の算出ロジックの引っ越し
- Botへの組み込み

## レビュー観点
- [x] 算出用クラスの算出ロジックに怪しい部分はないか、セルフコメントとの乖離はないか
- [x] Botへの組み込みはうまくできているか
    - コミットメッセにもあるように雰囲気で組み込みました
    - 組み込み方針これでいいかの相談をしたいです……？
    - DiscordBot用のTokenを所持しておらず、動作確認が出来ていない状態です……お手数かけます