### PR TITLE
refactor: typing, logging

### DIFF
--- a/cogs/artifact_constants.py
+++ b/cogs/artifact_constants.py
@@ -1,6 +1,6 @@
-from decimal import Decimal, ROUND_HALF_UP, ROUND_DOWN
 import itertools
 import statistics
+from decimal import ROUND_DOWN, ROUND_HALF_UP, Decimal
 
 
 class ArtifactConstants:
@@ -34,27 +34,31 @@ class ArtifactConstants:
         pass
 
     @staticmethod
-    def quantize(value: float, rank: str='0.1', method:str = ROUND_DOWN) -> Decimal:
+    def quantize(value: float, rank: str = '0.1', method: str = ROUND_DOWN) -> Decimal:
         return Decimal(value).quantize(Decimal(rank), method)
 
     @staticmethod
     def _calc_display_to_internal(attr: str):
         """キー毎に、表示値から、内部値を算出する"""
-        indexes:list[tuple[int]] = []
+        indexes: list[tuple[int]] = []
         # 上昇値のインデックスである 0 - 3 の配列から、 重複を含みかつ並べ替えて一致しない i 個のペアを生成する
         increase_index = range(4)
         for i in range(7):
-            indexes.extend(itertools.combinations_with_replacement(increase_index, i))
+            indexes.extend(
+                itertools.combinations_with_replacement(increase_index, i)
+            )
 
         # 内部値の配列に持ち替える
-        display_to_internal_values: dict[float,list[float]]= {}
+        display_to_internal_values: dict[float, list[float]] = {}
         for x in indexes:
             disp = float(ArtifactConstants.quantize(
                 sum([ArtifactConstants.INCREASE_TABLE[attr][i] for i in x]),
                 ArtifactConstants.ROUND_RANK[attr],
                 ROUND_HALF_UP,
             ))
-            internal = sum([ArtifactConstants.INCREASE_TABLE[attr][i] for i in x])
+            internal = sum(
+                [ArtifactConstants.INCREASE_TABLE[attr][i] for i in x]
+            )
 
             if disp in display_to_internal_values:
                 display_to_internal_values[disp].append(internal)
@@ -75,7 +79,7 @@ class ArtifactConstants:
     @staticmethod
     def calc_display_to_internal():
         """表示値から、内部値を算出し、辞書に整形する
-        
+
         :example:
         ```
         >>> ArtifactConstants.calc_display_to_internal()
@@ -90,5 +94,3 @@ class ArtifactConstants:
         for k in ArtifactConstants.ROUND_RANK.keys():
             result[k] = ArtifactConstants._calc_display_to_internal(k)
         return result
-            
-

--- a/cogs/artifact_score.py
+++ b/cogs/artifact_score.py
@@ -98,7 +98,7 @@ class ArtifactScore:
 
         result = inner_value / denominator
 
-        print(f'{attr}: {inner_value} / {denominator} = {result}')
+        logger.debug(f'{attr}: {inner_value} / {denominator} = {result}')
         return result
 
     def calc_theoretical_rate(

--- a/main.py
+++ b/main.py
@@ -51,4 +51,4 @@ class Bot(commands.Bot):
 
 
 if __name__ == '__main__':
-    Bot().run()
+    Bot().run(log_handler=None)

--- a/main.py
+++ b/main.py
@@ -1,14 +1,21 @@
-from discord.ext import commands
+import logging
+from typing import Any
+
 import discord
+from discord import Message
+from discord.ext import commands
 
 import config
+
+logger = logging.getLogger(__name__)
+discord.utils.setup_logging(level=logging.INFO)
 
 cogs = [
     'cogs.artifact'
 ]
 
 
-def get_prefix(bot, message):
+def get_prefix(bot: commands.Bot, message: Message):
     return commands.when_mentioned_or(config.prefix)(bot, message)
 
 
@@ -26,13 +33,17 @@ class Bot(commands.Bot):
             await self.load_extension(cog)
         await self.tree.sync()
 
-    def run(self):
-        super().run(config.token)
+    def run(
+        self,
+        token: str = config.token,
+        **kwargs: Any,
+    ):
+        super().run(token, **kwargs)
 
     async def on_ready(self):
-        print('ready')
+        logger.info('ready')
 
-    async def on_message(self, message):
+    async def on_message(self, message: Message):
         if message.author.bot:
             return
 


### PR DESCRIPTION
### やったこと
- 型ヒントとログの改善を行った
- フォーマッタをかけた
- サーバーでの動作確認を行った

### レビュー観点
- [x] 型Hintで気になる点はないか
- [x] loggerに直しそこねているprintはないか
    - ArtifactorScore の `if __name__  == '__main__'`配下はテスト用なので適用外とした 
- [x] その他なにか気になることは無いか

### ログ出力参考
```
2023-04-14 15:23:50 WARNING  discord.client PyNaCl is not installed, voice will NOT be supported   
2023-04-14 15:23:50 INFO     discord.client logging in using static token
2023-04-14 15:23:50 INFO     discord.client logging in using static token
2023-04-14 15:23:52 INFO     discord.gateway Shard ID None has connected to Gateway (Session ID: 64e42cb4801f1f4d4a94b887b12a6b12).
2023-04-14 15:23:52 INFO     discord.gateway Shard ID None has connected to Gateway (Session ID: 64e42cb4801f1f4d4a94b887b12a6b12).
2023-04-14 15:23:54 INFO     __main__ ready
2023-04-14 15:24:36 ERROR    cogs.artifact_score Error occured by mapping DISPLAY_TO_INTERNAL at crit_rate 9.9
2023-04-14 15:24:36 ERROR    cogs.artifact_score Error occured by mapping DISPLAY_TO_INTERNAL at crit_rate 9.9
2023-04-14 15:24:36 ERROR    cogs.artifact_score Error occured by mapping DISPLAY_TO_INTERNAL at crit_rate 9.9
```
ERRORはOCRの読み取りミスで、3.9が9.9に読まれたことによるのもので実装は問題ない。

### 参考
- https://discordpy.readthedocs.io/en/stable/logging.html
- https://discordpy.readthedocs.io/en/stable/ext/commands/api.html?highlight=converter#discord.ext.commands.Converter