### PR TITLE
算出回数が少なくなるよう調整

### DIFF
--- a/cogs/artifact_constants.py
+++ b/cogs/artifact_constants.py
@@ -1,10 +1,23 @@
 import itertools
 import statistics
 from decimal import ROUND_DOWN, ROUND_HALF_UP, Decimal
+from typing import Literal
 
+AttrKeys = Literal[
+    'fixed_hp',
+    'fixed_atk',
+    'fixed_def',
+    'rated_hp',
+    'rated_atk',
+    'rated_def',
+    'crit_dmg',
+    'crit_rate',
+    'charge_rate',
+    'elemental_mastery',
+]
 
 class ArtifactConstants:
-    INCREASE_TABLE = {
+    INCREASE_TABLE: dict[AttrKeys, list[float]] = {
         'fixed_hp': [209.13, 239.00, 268.88, 298.75],
         'fixed_atk': [13.62, 15.56, 17.51, 19.45],
         'fixed_def': [16.20, 18.52, 20.83, 23.15],
@@ -17,7 +30,7 @@ class ArtifactConstants:
         'elemental_mastery': [16.32, 18.65, 20.98, 23.31],
     }
 
-    ROUND_RANK = {
+    ROUND_RANK: dict[AttrKeys, str] = {
         'fixed_hp': '1',
         'fixed_atk': '1',
         'fixed_def': '1',
@@ -38,7 +51,7 @@ class ArtifactConstants:
         return Decimal(value).quantize(Decimal(rank), method)
 
     @staticmethod
-    def _calc_display_to_internal(attr: str):
+    def _calc_display_to_internal(attr: AttrKeys):
         """キー毎に、表示値から、内部値を算出する"""
         indexes: list[tuple[int]] = []
         # 上昇値のインデックスである 0 - 3 の配列から、 重複を含みかつ並べ替えて一致しない i 個のペアを生成する
@@ -90,7 +103,7 @@ class ArtifactConstants:
         }
         ```
         """
-        result: dict[str, dict[float, float]] = {}
+        result: dict[AttrKeys, dict[float, float]] = {}
         for k in ArtifactConstants.ROUND_RANK.keys():
             result[k] = ArtifactConstants._calc_display_to_internal(k)
         return result

--- a/cogs/artifact_score.py
+++ b/cogs/artifact_score.py
@@ -1,7 +1,10 @@
 from decimal import ROUND_HALF_UP, Decimal
 import logging
+from typing import Literal
 
-from .artifact_constants import ArtifactConstants
+from .artifact_constants import ArtifactConstants, AttrKeys
+
+G_CalcType = Literal['rated_hp', 'rated_atk', 'rated_def', 'crit_only', 'em', 'er']
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +46,7 @@ class ArtifactScore:
     ) -> Decimal:
         return ArtifactConstants.quantize(value, rank, method)
 
-    def _get_inner_option_value(self, attr: str, value: float) -> float:
+    def _get_inner_option_value(self, attr: AttrKeys, value: float) -> float:
         """表示値から内部の値を算出する"""
         result = value
         try:
@@ -65,7 +68,7 @@ class ArtifactScore:
 
         return result
 
-    def _calc_by_general_score_logic(self, calc_type: str) -> float:
+    def _calc_by_general_score_logic(self, calc_type: G_CalcType) -> float:
         if calc_type == 'rated_hp':
             return self.crit_rate * 2 + self.crit_dmg + self.rated_hp
         if calc_type == 'rated_atk':
@@ -80,14 +83,14 @@ class ArtifactScore:
             return self.crit_rate * 2 + self.crit_dmg + self.charge_rate
         return 0
 
-    def calc_general_rate(self, calc_type: str) -> Decimal:
+    def calc_general_rate(self, calc_type: G_CalcType) -> Decimal:
         return self._quantize(
             self._calc_by_general_score_logic(calc_type),
             method=ROUND_HALF_UP,
         )
 
     def _calc_theoretical_rate(
-        self, attr: str, initial: int = 1, raises: int = 5
+        self, attr: AttrKeys, initial: int = 1, raises: int = 5
     ) -> float:
         """
         オプション上昇理論値から見た割合を算出する
@@ -108,7 +111,7 @@ class ArtifactScore:
         return result
 
     def calc_theoretical_rate(
-        self, attrs: 'list[str] | None' = None, raises: int = 5
+        self, attrs: 'list[AttrKeys] | None' = None, raises: int = 5
     ) -> Decimal:
         """
         選択したオプションと、上昇回数から想定される理論値から見た割合を算出する


### PR DESCRIPTION
## やったこと
- ボットの返答に使用されないスコアの算出がなくなるようにした
- 型を少し強固にした

## 確認したこと
- ログの算出回数が減ったこと
```
2023-04-16 13:01:59 WARNING  discord.client PyNaCl is not installed, voice will NOT be supported
2023-04-16 13:01:59 INFO     discord.client logging in using static token
2023-04-16 13:02:01 INFO     discord.gateway Shard ID None has connected to Gateway (Session ID: 2f119e41cd5153b868cd167b13a1c2d8).
2023-04-16 13:02:26 ERROR    cogs.artifact_score Error occured by mapping DISPLAY_TO_INTERNAL at crit_rate 9.9
```
- 自身のサーバーで動作確認をした

## 確認してほしいこと
- [ ] 修正方針はコレで問題ないか
- [ ] 型の命名でよりわかりやすいものはあるか
- [ ] 他になにか気になることはないか